### PR TITLE
docs: sync README badge to website-data.json and update tagline

### DIFF
--- a/.claude/commands/release-tag.md
+++ b/.claude/commands/release-tag.md
@@ -96,7 +96,7 @@ After the version bump, update `website-data.json` to reflect current codebase m
 - `backendTests`: count via `cargo test --workspace 2>&1 | awk '/test result/{sum+=$4} END{print sum}'`
 - Other fields (`binarySize`, `debRpmSize`, `startupSeconds`, `llmProviders`, `messagingChannels`, `crates`, `securityLayers`, `platformTargets`, `compileFlags`) — update only if you have reason to believe they changed.
 
-Read the current `website-data.json`, update only the fields above, write back. Do NOT ask the user — just update and proceed.
+Read the current `website-data.json`, update only the fields above, write back. After writing, read `backendTests` from it and update the test count badge in `README.md`: replace `tests-<N>-blue` with `tests-<backendTests>-blue` and `alt="<N> tests"` with `alt="<backendTests> tests"`. Do NOT ask the user — just update and proceed.
 
 ### Step 4: Update CHANGELOG body
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -49,6 +49,7 @@ Review the staged and unstaged changes (use `git diff` and `git diff --cached`) 
    - `backendTests`: count via `cargo test --workspace 2>&1 | awk '/test result/{sum+=$4} END{print sum}'`
    - Other fields (`binarySize`, `debRpmSize`, `startupSeconds`, `llmProviders`, `messagingChannels`, `crates`, `securityLayers`, `platformTargets`, `compileFlags`) — update manually only if the code changes warrant it.
    - Read the current `website-data.json`, apply only the fields that changed, write back.
+   - After writing `website-data.json`, read `backendTests` from it and update the test count badge in `README.md`: replace `tests-<N>-blue` with `tests-<backendTests>-blue` and `alt="<N> tests"` with `alt="<backendTests> tests"`.
 4. **`docs/` directory** — Update relevant docs if the changes affect:
    - `docs/architecture.md` — new modules, traits, data flows, or structural changes
    - `docs/phases.md` — phase status changes or deliverable updates

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   Run a daemon at <code>localhost:18981</code>. Your desktop app, CLI, TUI, scripts,
-  and MCP clients share the same memory, tools, providers, and permissions — no sync, no duplication.
+  and MCP clients share the same memory, tools, providers, channels, and scheduler — no sync, no duplication.
 </p>
 
 <p align="center">
@@ -22,7 +22,7 @@
     <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" alt="MIT license" />
   </a>
   <a href="https://github.com/sprklai/zenii/actions/workflows/ci.yml">
-    <img src="https://img.shields.io/badge/tests-1720-blue?style=flat-square" alt="1720 tests" />
+    <img src="https://img.shields.io/badge/tests-1696-blue?style=flat-square" alt="1696 tests" />
   </a>
   <a href="https://github.com/sprklai/zenii/pulls">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square" alt="PRs welcome" />


### PR DESCRIPTION
## Summary
- Wire test count badge in README to `backendTests` from `website-data.json` (1720→1696); badge was drifting from the actual count
- Add README badge sync step to `/ship` and `/release-tag` commands so the badge auto-updates going forward
- Update hero tagline to mention channels and scheduler (both fully shipped)

## Test plan
- [ ] Verify README badge shows `tests-1696`
- [ ] Run `/ship` after next code change — confirm badge updates to match new `backendTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)